### PR TITLE
Fix parentheses when running script block immediately

### DIFF
--- a/Undo-WinRMConfig.ps1
+++ b/Undo-WinRMConfig.ps1
@@ -114,7 +114,7 @@ Function Setup-Undo {
   If ($RunImmediately)
   {
     Write-Output 'Undoing WinRM Config Right Now (do NOT execute this over remoting or this code will not complete)...'  
-    Invoke-Command -ScriptBlock [Scriptblock]::Create($UndoWinRMScript)
+    Invoke-Command -ScriptBlock ([Scriptblock]::Create($UndoWinRMScript))
     exit 0
   }
   else 


### PR DESCRIPTION
Creating a script block to pass to `Invoke-Command` needs another set of
parentheses, otherwise PowerShell gives the parse error:

```powershell
Invoke-Command: Cannot bind parameter 'ScriptBlock'. Cannot convert the
"[scriptblock]::Create" value of type "System.String" to type
"System.Management.Automation.ScriptBlock".
```